### PR TITLE
Added method for DataFrame column name validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-model-solver"
-version = "1.3.0"
+version = "1.4.0"
 description = "Class to define, block analyse and solve dynamic and algebraic models numerically"
 authors = ["Benedikt Goodman <benedikt.goodman@ssb.no>"]
 license = "MIT"

--- a/src/model_solver/model_solver.py
+++ b/src/model_solver/model_solver.py
@@ -843,23 +843,6 @@ class ModelSolver:
                 1. If the DataFrame has no columns
                 2. If any column names are duplicated (error message will include
                 which columns are duplicated and their count)
-
-        Examples:
-            >>> import ModelSolver
-            >>> import pandas as pd
-            >>> # Raises error for empty DataFrame
-            >>> df_empty = pd.DataFrame()
-            >>> ModelSolver._validate_unique_column_names(df_empty)
-            ValueError: DataFrame has no columns
-
-            >>> # Raises error for duplicate columns
-            >>> df_dupes = pd.DataFrame(columns=['A', 'B', 'A'])
-            >>> ModelSolver._validate_unique_column_names(df_dupes)
-            ValueError: Found duplicate column names in DataFrame. The following columns appear multiple times: {'A': 2}
-
-            >>> # Passes with unique columns
-            >>> df_valid = pd.DataFrame(columns=['A', 'B', 'C'])
-            >>> ModelSolver._validate_unique_column_names(df_valid)  # No error raised
         """
         col_counts = df.columns.value_counts().sum()
         if col_counts == 0:

--- a/src/model_solver/model_solver.py
+++ b/src/model_solver/model_solver.py
@@ -847,7 +847,6 @@ class ModelSolver:
         Examples:
             >>> import ModelSolver
             >>> import pandas as pd
-            
             >>> # Raises error for empty DataFrame
             >>> df_empty = pd.DataFrame()
             >>> ModelSolver._validate_unique_column_names(df_empty)

--- a/src/model_solver/model_solver.py
+++ b/src/model_solver/model_solver.py
@@ -4,7 +4,6 @@
 # mkh@ssb.no/magnus.helliesen@gmail.com #
 #########################################
 
-from ast import Raise
 from collections import Counter
 from collections.abc import Callable
 from collections.abc import Generator

--- a/src/model_solver/model_solver.py
+++ b/src/model_solver/model_solver.py
@@ -842,7 +842,7 @@ class ModelSolver:
         Raises:
             ValueError: In two cases:
                 1. If the DataFrame has no columns
-                2. If any column names are duplicated (error message will include 
+                2. If any column names are duplicated (error message will include
                 which columns are duplicated and their count)
 
         Examples:
@@ -863,14 +863,14 @@ class ModelSolver:
         col_counts = df.columns.value_counts().sum()
         if col_counts == 0:
             raise ValueError("DataFrame has no columns")
-            
+
         if len(df.columns) > df.columns.nunique():
             counts = df.columns.value_counts()
             duplicates = counts[counts > 1]
             raise ValueError(
-                f'Found duplicate column names in DataFrame. '
-                f'The following columns appear multiple times: '
-                f'{duplicates.to_dict()}'
+                f"Found duplicate column names in DataFrame. "
+                f"The following columns appear multiple times: "
+                f"{duplicates.to_dict()}"
             )
 
     def solve_model(self, input_df: pd.DataFrame, jit: bool = True) -> pd.DataFrame:

--- a/src/model_solver/model_solver.py
+++ b/src/model_solver/model_solver.py
@@ -914,7 +914,7 @@ class ModelSolver:
             Finished
             ----------------------------------------------------------------------------------------------------
         """
-        # Raises error if non-unique_names are detected
+        # Raises error if non-unique column names are detected or if dataframe is empty
         self._validate_unique_column_names(input_df)
 
         if (

--- a/src/model_solver/model_solver.py
+++ b/src/model_solver/model_solver.py
@@ -845,19 +845,22 @@ class ModelSolver:
                 which columns are duplicated and their count)
 
         Examples:
+            >>> import ModelSolver
+            >>> import pandas as pd
+            
             >>> # Raises error for empty DataFrame
             >>> df_empty = pd.DataFrame()
-            >>> _validate_unique_column_names(df_empty)
+            >>> ModelSolver._validate_unique_column_names(df_empty)
             ValueError: DataFrame has no columns
 
             >>> # Raises error for duplicate columns
             >>> df_dupes = pd.DataFrame(columns=['A', 'B', 'A'])
-            >>> _validate_unique_column_names(df_dupes)
+            >>> ModelSolver._validate_unique_column_names(df_dupes)
             ValueError: Found duplicate column names in DataFrame. The following columns appear multiple times: {'A': 2}
 
             >>> # Passes with unique columns
             >>> df_valid = pd.DataFrame(columns=['A', 'B', 'C'])
-            >>> _validate_unique_column_names(df_valid)  # No error raised
+            >>> ModelSolver._validate_unique_column_names(df_valid)  # No error raised
         """
         col_counts = df.columns.value_counts().sum()
         if col_counts == 0:

--- a/tests/test_model_solver.py
+++ b/tests/test_model_solver.py
@@ -185,6 +185,7 @@ def test_sensitivity(
     assert "k2" in sens_std.columns
     assert np.allclose(4.732277, sens_std["k2"].sum(), atol=0.00001)
 
+
 def test_validate_unique_column_names_passes() -> None:
     """Test that validation passes with unique column names."""
     df = pd.DataFrame(columns=["A", "B", "C"])
@@ -194,10 +195,10 @@ def test_validate_unique_column_names_passes() -> None:
 def test_validate_unique_column_names_fails_single_duplicate() -> None:
     """Test that validation fails with a single duplicated column."""
     df = pd.DataFrame(columns=["A", "B", "A"])
-    
+
     with pytest.raises(ValueError) as exc_info:
         ms.ModelSolver._validate_unique_column_names(df)
-    
+
     assert "Found duplicate column names in DataFrame" in str(exc_info.value)
     assert "{'A': 2}" in str(exc_info.value)
 
@@ -205,10 +206,10 @@ def test_validate_unique_column_names_fails_single_duplicate() -> None:
 def test_validate_unique_column_names_fails_multiple_duplicates() -> None:
     """Test that validation fails with multiple duplicated columns."""
     df = pd.DataFrame(columns=["A", "B", "A", "B", "C"])
-    
+
     with pytest.raises(ValueError) as exc_info:
         ms.ModelSolver._validate_unique_column_names(df)
-    
+
     assert "Found duplicate column names in DataFrame" in str(exc_info.value)
     # Check both duplicates are reported
     assert "'A': 2" in str(exc_info.value)

--- a/tests/test_model_solver.py
+++ b/tests/test_model_solver.py
@@ -184,3 +184,40 @@ def test_sensitivity(
     # k2 will be in the block analysed with current equation set
     assert "k2" in sens_std.columns
     assert np.allclose(4.732277, sens_std["k2"].sum(), atol=0.00001)
+
+def test_validate_unique_column_names_passes() -> None:
+    """Test that validation passes with unique column names."""
+    df = pd.DataFrame(columns=["A", "B", "C"])
+    ms.ModelSolver._validate_unique_column_names(df)  # Should pass without raising
+
+
+def test_validate_unique_column_names_fails_single_duplicate() -> None:
+    """Test that validation fails with a single duplicated column."""
+    df = pd.DataFrame(columns=["A", "B", "A"])
+    
+    with pytest.raises(ValueError) as exc_info:
+        ms.ModelSolver._validate_unique_column_names(df)
+    
+    assert "Found duplicate column names in DataFrame" in str(exc_info.value)
+    assert "{'A': 2}" in str(exc_info.value)
+
+
+def test_validate_unique_column_names_fails_multiple_duplicates() -> None:
+    """Test that validation fails with multiple duplicated columns."""
+    df = pd.DataFrame(columns=["A", "B", "A", "B", "C"])
+    
+    with pytest.raises(ValueError) as exc_info:
+        ms.ModelSolver._validate_unique_column_names(df)
+    
+    assert "Found duplicate column names in DataFrame" in str(exc_info.value)
+    # Check both duplicates are reported
+    assert "'A': 2" in str(exc_info.value)
+    assert "'B': 2" in str(exc_info.value)
+
+
+def test_validate_unique_column_names_empty_df() -> None:
+    """Test that validation passes with an empty DataFrame."""
+    df = pd.DataFrame()
+    with pytest.raises(ValueError) as exc_info:
+        ms.ModelSolver._validate_unique_column_names(df)
+    assert "DataFrame has no columns" in str(exc_info)


### PR DESCRIPTION
## Changes Made
- Added `_validate_unique_column_names` as a static method to `ModelSolver` class to enforce DataFrame column name uniqueness
- Implemented validation for both duplicate columns and empty DataFrames
- Added comprehensive tests

## Technical Details
- Method validates two conditions:
  1. DataFrame must have columns (not empty)
  2. All column names must be unique
- Provides detailed error messages showing exact duplicate columns and their counts
- Uses `df.columns.value_counts()` for efficient duplicate detection

## Testing
Added tests covering:
- Empty DataFrame detection
- Single duplicate column detection
- Multiple duplicate columns detection
- Valid DataFrame case (passes silently)

## Example Usage
```python
df = pd.DataFrame(columns=['A', 'B', 'A'])
ModelSolver._validate_unique_column_names(df)
# Raises: ValueError: Found duplicate column names in DataFrame. 
# The following columns appear multiple times: {'A': 2}