### PR TITLE
Bg column validation refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-model-solver"
-version = "1.4.0"
+version = "1.4.1"
 description = "Class to define, block analyse and solve dynamic and algebraic models numerically"
 authors = ["Benedikt Goodman <benedikt.goodman@ssb.no>"]
 license = "MIT"

--- a/src/model_solver/model_solver.py
+++ b/src/model_solver/model_solver.py
@@ -844,11 +844,11 @@ class ModelSolver:
                 2. If any column names are duplicated (error message will include
                 which columns are duplicated and their count)
         """
-        col_counts = df.columns.value_counts().sum()
-        if col_counts == 0:
+        total_columns = df.columns.value_counts().sum()
+        if total_columns == 0:
             raise ValueError("DataFrame has no columns")
 
-        if len(df.columns) > df.columns.nunique():
+        if total_columns > df.columns.nunique():
             counts = df.columns.value_counts()
             duplicates = counts[counts > 1]
             raise ValueError(


### PR DESCRIPTION
Patch that makes the _validate_unique_column_names more performant.

```python
# changed from using this
total_columns = len(df.columns)

# to using this, which is about 100x quicker
total_columns = df.columns.value_counts().sum()
```